### PR TITLE
Develop

### DIFF
--- a/marrow/mailer/message.py
+++ b/marrow/mailer/message.py
@@ -5,6 +5,7 @@
 import imghdr
 import os
 import time
+import base64
 
 from datetime import datetime
 from email.mime.text import MIMEText


### PR DESCRIPTION
Attachments are now base64-encoded (issue #64).  And added the ability specify the attachment filename rather than having to use the name of the on-disk file.
