### PR TITLE
py3k: don't attempt to decode `str` objects

### DIFF
--- a/marrow/mailer/transport/smtp.py
+++ b/marrow/mailer/transport/smtp.py
@@ -111,8 +111,11 @@ class SMTPTransport(object):
     def send_with_smtp(self, message):
         try:
             sender = str(message.envelope)
-            recipients = message.recipients.string_addresses
-            recipients = [addr.decode('utf-8') for addr in message.recipients.string_addresses]
+            if hasattr(str, "decode"):
+                # don't attempt to utf-8-decode strings in Python 3
+                recipients = [addr.decode('utf-8') for addr in message.recipients.string_addresses]
+            else:
+                recipients = message.recipients.string_addresses
             content = str(message)
 
             self.connection.sendmail(sender, recipients, content)


### PR DESCRIPTION
Python 3 `str` objects are Unicode already and don't need decoding.

https://github.com/marrow/mailer/issues/59