### PR TITLE
Fix Amazon SES issues

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -341,15 +341,14 @@ table(configuration).
 | @path@ | @"/usr/sbin/sendmail"@ | The path to the @sendmail@ executable. |
 
 
-h4(#ses-transport). %6.3.1.% Amazon Simple E-Mail Service (SES)
+h4(#amazon-transport). %6.3.1.% Amazon Simple E-Mail Service (SES)
 
-Deliver your messages via the Amazon Simple E-Mail Service.  While Amazon allow you to utilize SMTP for communication, using the correct API allows you to get much richer information back from delivery upon both success *and* failure.  To utilize this transport you must have the @boto@ package installed.
+Deliver your messages via the Amazon Simple E-Mail Service with the @amazon@ transport.  While Amazon allows you to utilize SMTP for communication, using the correct API allows you to get much richer information back from delivery upon both success *and* failure.  To utilize this transport you must have the @boto@ package installed.
 
 table(configuration).
 |_. Directive |_. Default |_. Description |
 | @id@ | — | Your Amazon AWS access key identifier. |
 | @key@ | — | Your Amazon AWS secret access key. |
-| @host@ | @"email.us-east-1.amazonaws.com"@ | The API endpoint to utilize. |
 
 
 

--- a/marrow/mailer/transport/ses.py
+++ b/marrow/mailer/transport/ses.py
@@ -23,6 +23,7 @@ class AmazonTransport(object): # pragma: no cover
         config['aws_secret_access_key'] = config.pop('key')
         
         self.region = config.pop('region', "us-east-1")
+        config.pop('use') #boto throws an error if we leave this in the next line
         self.config = config  # All other configuration directives are passed to connect_to_region.
         self.connection = None
     


### PR DESCRIPTION
Using mailer 4.0.1 with Python 2.7 and boto 2.38, the `amazon` transport doesn't work out of the box.

- The transport file is called `ses.py` but the transport is `amazon`.
- boto doesn't know what to do with the `host` argument in the README, and throws this error:  `TypeError: __init__() got an unexpected keyword argument 'host'`
- boto doesn't know what to do with marrow mailer's `use` argument, and throws this error: `TypeError: __init__() got an unexpected keyword argument 'use'`

This pull request resolves these issues by:

- `README.textile` now specifies that the transport is called `amazon`, addressing #57 (although not providing an `ses` alias).
- The `host` line is removed from `README.textile`.
- The `use` argument is popped before any other parameters are passed into config.

With these changes I can successfully send mail.