### PR TITLE
Fixed Py3 compatibility

### DIFF
--- a/marrow/mailer/transport/postmark.py
+++ b/marrow/mailer/transport/postmark.py
@@ -65,7 +65,7 @@ class PostmarkTransport(object):
 
         try:
             response = urllib2.urlopen(request)
-        except (urllib2.HTTPError, urllib2.URLError), e:
+        except (urllib2.HTTPError, urllib2.URLError) as e:
             raise DeliveryFailedException(e, "Could not connect to Postmark.")
         else:
             respcode = response.getcode()


### PR DESCRIPTION
Hello.

I downloaded the latest release of the mailer from PyPI and when I tried to run `python setup.py install` with Python 3.5.1 I get the following error:

```
byte-compiling build/bdist.linux-x86_64/egg/marrow/mailer/transport/postmark.py to postmark.cpython-35.pyc
  File "build/bdist.linux-x86_64/egg/marrow/mailer/transport/postmark.py", line 68
    except (urllib2.HTTPError, urllib2.URLError), e:
                                                ^
SyntaxError: invalid syntax
```

It looks like Python 3 incompatibility so I've changed this line and now installation works for Python 2 and 3.