### PR TITLE
Attach files with filenames that include non-ASCII characters

### DIFF
--- a/marrow/mailer/message.py
+++ b/marrow/mailer/message.py
@@ -258,7 +258,8 @@ class Message(object):
 		return message
 
 	def attach(self, name, data=None, maintype=None, subtype=None,
-		inline=False, filename=None, encoding=None):
+		inline=False, filename=None, filename_charset='', filename_language='',
+		content_encoding=None):
 		"""Attach a file to this message.
 
 		:param name: Path to the file to attach if data is None, or the name
@@ -274,14 +275,17 @@ class Message(object):
 					   "inline" (True) or "attachment" (False)
 		:param filename: The file name of the attached file as seen
 									by the user in his/her mail client.
-		:param encoding: Value of the Content-Encoding MIME header (e.g. "gzip"
+		:param filename_charset: Charset used for the filename paramenter. Allows for 
+						attachment names with characters from UTF-8 or Latin 1. See RFC 2231.
+		:param filename_language: Used to specify what language the filename is in. See RFC 2231.
+		:param content_encoding: Value of the Content-Encoding MIME header (e.g. "gzip"
 						 in case of .tar.gz, but usually empty)
 		"""
 		self._dirty = True
 
 		if not maintype:
 			maintype, guessed_encoding = guess_type(name)
-			encoding = encoding or guessed_encoding
+			content_encoding = content_encoding or guessed_encoding
 			if not maintype:
 				maintype, subtype = 'application', 'octet-stream'
 			else:
@@ -290,7 +294,7 @@ class Message(object):
 		part = MIMENonMultipart(maintype, subtype)
 		part.add_header('Content-Transfer-Encoding', 'base64')
 
-		if encoding:
+		if content_encoding:
 			part.add_header('Content-Encoding', encoding)
 
 		if data is None:
@@ -309,7 +313,15 @@ class Message(object):
 		if not filename:
 			filename = name
 		filename = os.path.basename(filename)
-		
+
+		if filename_charset or filename_language:
+			# See https://docs.python.org/2/library/email.message.html#email.message.Message.add_header
+			# for more information.
+			# add_header() in the email module expects its arguments to be ASCII strings. Go ahead and handle
+			# the case where these arguments come in as unicode strings, since encoding ASCII strings
+			# as UTF-8 can't hurt.
+			filename=(filename_charset.encode('utf-8'), filename_language.encode('utf-8'), filename.encode('utf-8'))
+
 		if inline:
 			part.add_header('Content-Disposition', 'inline', filename=filename)
 			part.add_header('Content-ID', '<%s>' % filename)

--- a/marrow/mailer/message.py
+++ b/marrow/mailer/message.py
@@ -259,7 +259,7 @@ class Message(object):
 
 	def attach(self, name, data=None, maintype=None, subtype=None,
 		inline=False, filename=None, filename_charset='', filename_language='',
-		content_encoding=None):
+		encoding=None):
 		"""Attach a file to this message.
 
 		:param name: Path to the file to attach if data is None, or the name
@@ -278,14 +278,14 @@ class Message(object):
 		:param filename_charset: Charset used for the filename paramenter. Allows for 
 						attachment names with characters from UTF-8 or Latin 1. See RFC 2231.
 		:param filename_language: Used to specify what language the filename is in. See RFC 2231.
-		:param content_encoding: Value of the Content-Encoding MIME header (e.g. "gzip"
+		:param encoding: Value of the Content-Encoding MIME header (e.g. "gzip"
 						 in case of .tar.gz, but usually empty)
 		"""
 		self._dirty = True
 
 		if not maintype:
 			maintype, guessed_encoding = guess_type(name)
-			content_encoding = content_encoding or guessed_encoding
+			encoding = encoding or guessed_encoding
 			if not maintype:
 				maintype, subtype = 'application', 'octet-stream'
 			else:
@@ -294,7 +294,7 @@ class Message(object):
 		part = MIMENonMultipart(maintype, subtype)
 		part.add_header('Content-Transfer-Encoding', 'base64')
 
-		if content_encoding:
+		if encoding:
 			part.add_header('Content-Encoding', encoding)
 
 		if data is None:


### PR DESCRIPTION
[RFC 2231](https://tools.ietf.org/html/rfc2231) allows us to specify a language and a charset for filenames that include non-ASCII characters. Python's `email` module already includes some nifty functionality to handle this.  This PR simply exposes that functionality to users of marrow/mailer.