### PR TITLE
In Python 2.7, encode strings in add_header() as ASCII

### DIFF
--- a/marrow/mailer/message.py
+++ b/marrow/mailer/message.py
@@ -322,11 +322,18 @@ class Message(object):
 				filename=(filename_charset, filename_language, filename)
 		
 		if inline:
-			part.add_header('Content-Disposition', 'inline', filename=filename)
-			part.add_header('Content-ID', '<%s>' % filename)
+			if sys.version_info < (3, 0):
+				part.add_header('Content-Disposition'.encode('utf-8'), 'inline'.encode('utf-8'), filename=filename)
+				part.add_header('Content-ID'.encode('utf-8'), '<%s>'.encode('utf-8') % filename)
+			else:	
+				part.add_header('Content-Disposition', 'inline', filename=filename)
+				part.add_header('Content-ID', '<%s>' % filename)
 			self.embedded.append(part)
 		else:
-			part.add_header('Content-Disposition', 'attachment', filename=filename)
+			if sys.version_info < (3, 0):
+				part.add_header('Content-Disposition'.encode('utf-8'), 'attachment'.encode('utf-8'), filename=filename)
+			else:
+				part.add_header('Content-Disposition', 'attachment', filename=filename)
 			self.attachments.append(part)
 
 	def embed(self, name, data=None):

--- a/test/test_message.py
+++ b/test/test_message.py
@@ -300,7 +300,10 @@ class TestBasicMessage(TestCase):
 		filename = attachment.get_param('filename', object(), 'content-disposition') # get_filename() calls this under the covers
 		assert isinstance(filename, tuple)  # Since attachment encoded according to RFC2231, should be represented as a tuple		
 		filename = attachment.get_filename()  # Calls email.utils.collapse_rfc2231_value() under the covers, currently fails
-		assert isinstance(filename, basestring)  # Successfully converts tuple to Unicode string
+		if sys.version_info < (3, 0):
+			assert isinstance(filename, basestring)  # Successfully converts tuple to a string
+		else:
+			assert isinstance(filename, str)
 	
 	def test_recipients_collection(self):
 		message = self.build_message()


### PR DESCRIPTION
Fixes #71.

Because of how `add_header()` works under the covers, although we previously were encoding the information for the attachment name as ASCII, when we joined this information with the other arguments in the `add_header()` call (which are actually Unicode literals, due to an import statement at the top of the file) the entire header would be represented as a Unicode literal.

Thus, calling `get_param()` would successfully parse the string into a tuple according to RFC 2231, but all the strings are Unicode. Thus, calling `email.utils.collapse_rfc2231_value()` on this tuple will fail as it expects ASCII strings, not Unicode.

cc: @amcgregor 