### PR TITLE
Exclude `test`, not `tests`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
 				"Topic :: Utilities",
 			],
 		
-		packages = find_packages(exclude=['examples', 'tests']),
+		packages = find_packages(exclude=['example', 'test', 'test.*']),
 		include_package_data = True,
 		package_data = {'': ['README.textile', 'LICENSE.txt']},
 		namespace_packages = ['marrow'],


### PR DESCRIPTION
This project `setup.py` currently contains the line:

```
packages = find_packages(exclude=['examples', 'tests']),
```

However, there are no directories named `examples` and `tests` to exclude; the correct names are `example` and `test`.  As a result, the `test` directory is currently included in the project's built wheel files, which is generally not what you want.  This PR changes the line above to exclude `example` and `test` instead and also to exclude all directories under `test`.