### PR TITLE
Delete `optimize` setting from setup.cfg, as it causes .pyc files to be included in the wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,9 +12,6 @@ bdist-base = .packaging/dist
 [build]
 build-base = .packaging/build
 
-[install]
-optimize = 1
-
 [bdist]
 bdist-base = .packaging/dist
 dist-dir = .packaging/release


### PR DESCRIPTION
The project's `setup.cfg` currently contains the lines:

```
[install]
optimize = 1
```

This has the side effect of causing optimized `*.pyc` files to be compiled & included in the wheel generated by the `bdist_wheel` command.  Such files have no business being in a wheel, as (a) the files are machine-specific and thus won't be of use to most users, and (b) pip compiles its own set of `*.pyc` files when installing from a wheel anyway.  The setting is also of marginal utility to begin with, as it its intended purpose only takes effect when installing with `setup.py install`, which is deprecated in favor of installing with pip.  This PR thus removes the above lines from `setup.cfg`.