### PR TITLE
FIX TLS in SMTP.py

### DIFF
--- a/marrow/mailer/transport/smtp.py
+++ b/marrow/mailer/transport/smtp.py
@@ -67,11 +67,11 @@ class SMTPTransport(object):
                 self.connection = None
 
     def connect_to_server(self):
-        if self.tls == 'ssl': # pragma: no cover
-            connection = SMTP_SSL(local_hostname=self.local_hostname, keyfile=self.keyfile,
-                                  certfile=self.certfile, timeout=self.timeout)
+        if self.tls == "ssl":
+            connection = SMTP_SSL(host=self.host,local_hostname=self.local_hostname,keyfile=self.keyfile,certfile=self.certfile,timeout=self.timeout,)
+
         else:
-            connection = SMTP(local_hostname=self.local_hostname, timeout=self.timeout)
+            connection = SMTP(host=self.host, local_hostname=self.local_hostname, timeout=self.timeout)
 
         log.info("Connecting to SMTP server %s:%s", self.host, self.port)
         connection.set_debuglevel(self.debug)


### PR DESCRIPTION
Added Syntax for TLS host = self.host in TLS SSL Mode for SMTP Connection, Fixes Issues when Using SSL in SMTP