### PR TITLE
SES migrate to Signature Version 4

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -22,7 +22,7 @@ By using Marrow Mailer you can:
 * Deliver e-mail through a number of alternative transports including SMTP, Amazon SES, sendmail, or even via direct on-disk mbox/maildir.
 * Multiple simultaneous configurations for more targeted delivery.
 
-Mailer supports Python 2.6+ and 3.2+ and there are only light-weight dependencies: @marrow.util@, @marrow.interface@, and @boto@ if using Amazon SES.
+Mailer supports Python 2.6+ and 3.2+ and there are only light-weight dependencies: @marrow.util@, @marrow.interface@, and @boto3@ if using Amazon SES.
 
 
 h3(#goals). %1.1.% Goals
@@ -345,7 +345,7 @@ table(configuration).
 
 h4(#amazon-transport). %6.3.1.% Amazon Simple E-Mail Service (SES)
 
-Deliver your messages via the Amazon Simple E-Mail Service with the @amazon@ transport.  While Amazon allows you to utilize SMTP for communication, using the correct API allows you to get much richer information back from delivery upon both success *and* failure.  To utilize this transport you must have the @boto@ package installed.
+Deliver your messages via the Amazon Simple E-Mail Service with the @amazon@ transport.  While Amazon allows you to utilize SMTP for communication, using the correct API allows you to get much richer information back from delivery upon both success *and* failure.  To utilize this transport you must have the @boto3@ package installed.
 
 table(configuration).
 |_. Directive |_. Default |_. Description |

--- a/marrow/mailer/release.py
+++ b/marrow/mailer/release.py
@@ -5,7 +5,7 @@
 from collections import namedtuple
 
 
-version_info = namedtuple('version_info', ('major', 'minor', 'micro', 'releaselevel', 'serial'))(4, 0, 3, 'final', 0)
+version_info = namedtuple('version_info', ('major', 'minor', 'micro', 'releaselevel', 'serial'))(4, 1, 3, 'dev', 0)
 version = ".".join([str(i) for i in version_info[:3]]) + ((version_info.releaselevel[0] + str(version_info.serial)) if version_info.releaselevel != 'final' else '')
 
 author = namedtuple('Author', ['name', 'email'])("Alice Bevan-McGregor", 'alice@gothcandy.com')

--- a/marrow/mailer/transport/ses.py
+++ b/marrow/mailer/transport/ses.py
@@ -5,7 +5,7 @@ try:
     from botocore.exceptions import ClientError
 
 except ImportError:
-    raise ImportError("You must install the boto package to deliver mail via Amazon SES.")
+    raise ImportError("You must install the boto3 package to deliver mail via Amazon SES.")
 
 
 __all__ = ['AmazonTransport']

--- a/marrow/mailer/transport/ses.py
+++ b/marrow/mailer/transport/ses.py
@@ -5,8 +5,7 @@ try:
     from botocore.exceptions import ClientError
 
 except ImportError:
-    raise ImportError(
-        "You must install the boto package to deliver mail via Amazon SES.")
+    raise ImportError("You must install the boto package to deliver mail via Amazon SES.")
 
 
 __all__ = ['AmazonTransport']
@@ -31,8 +30,7 @@ class AmazonTransport(object):  # pragma: no cover
         self.connection = None
 
     def startup(self):
-        self.connection = boto3.client(
-            'ses', region_name=self.region, **self.config)
+        self.connection = boto3.client('ses', region_name=self.region, **self.config)
 
     def deliver(self, message):
         try:

--- a/marrow/mailer/transport/ses.py
+++ b/marrow/mailer/transport/ses.py
@@ -5,7 +5,8 @@ try:
     from botocore.exceptions import ClientError
 
 except ImportError:
-    raise ImportError("You must install the boto package to deliver mail via Amazon SES.")
+    raise ImportError(
+        "You must install the boto package to deliver mail via Amazon SES.")
 
 
 __all__ = ['AmazonTransport']
@@ -13,47 +14,46 @@ __all__ = ['AmazonTransport']
 log = __import__('logging').getLogger(__name__)
 
 
-
-class AmazonTransport(object): # pragma: no cover
+class AmazonTransport(object):  # pragma: no cover
     __slots__ = ('ephemeral', 'config', 'region', 'connection')
-    
+
     def __init__(self, config):
         # Give our configuration aliases their proper names.
         config['aws_access_key_id'] = config.pop('id')
         config['aws_secret_access_key'] = config.pop('key')
-        
+
         self.region = config.pop('region', "us-east-1")
-        config.pop('use') #boto throws an error if we leave this in the next line
+        # boto throws an error if we leave this in the next line
+        config.pop('use')
         config.pop('debug')
-        self.config = config  # All other configuration directives are passed to connect_to_region.
+        # All other configuration directives are passed to connect_to_region.
+        self.config = config
         self.connection = None
-    
+
     def startup(self):
-        self.connection = boto3.client('ses',region_name=self.region, **self.config)
-    
+        self.connection = boto3.client(
+            'ses', region_name=self.region, **self.config)
+
     def deliver(self, message):
         try:
             destinations = [str(r) for r in message.recipients]
             response = self.connection.send_raw_email(
-                                    Destinations=destinations,
-                                    RawMessage={
-                                        'Data': str(message)
-                                    },
-                                    Source=str(message.author),
-                                )
-                                
-            
+                RawMessage = {'Data': str(message)},
+                Source = str(message.author),
+                Destinations = destinations,
+            )
+
             return (
-                    response.get('MessageId', 'messageId NOT FOUND'),
-                    response.get('RequestId', {}).get('ResponseMetadata')
-                )
-        
+                response.get('MessageId', 'messageId NOT FOUND'),
+                response.get('RequestId', {}).get('ResponseMetadata')
+            )
+
         except ClientError as e:
-            raise # TODO: Raise appropriate internal exception.
+            raise  # TODO: Raise appropriate internal exception.
             # ['status', 'reason', 'body', 'request_id', 'error_code', 'error_message']
-    
+
     def shutdown(self):
         # if self.connection:
         #     self.connection.close()
-        
+
         self.connection = None


### PR DESCRIPTION
Amazon Simple Email Service (SES) had extended support for Signature Version 3 to February 28th, 2021. To continue to use Amazon SES, you must migrate to Signature Version 4 which offers enhanced security for authentication and authorization of Amazon SES customers.

We have identified that, between 2021-04-05 and 2021-04-12, your AWS account *** used Signature Version 3 to call Amazon SES APIs in the eu-west-1 Region.

Your Signature Version 3 requests were identified to be originating from:
- IAM Users: ****
- IPs: ****
- User Agents: Boto/2.49.0 Python/3.7.10 Linux/4.14.209-160.339.amzn2.x86_64, Boto/2.49.0 Python/3.7.8 Linux/4.14.209-160.339.amzn2.x86_64

Your Signature Version 3 requests were identified to be using the following SES actions:
- APIs: SendRawEmail

Example Request ID using Signature Version 3: ****

You can identify API requests that use Signature Version 3 by looking at the request headers. Requests that use the Signature Version 3 resemble the following example (note the "AWS3"):
X-Amzn-Authorization: AWS3-HTTPS AWSAccessKeyId=AKIAIOSFODNN7EXAMPLE,Algorithm=HMACSHA256,Signature=lBP67vCvGl ...

To move to Signature Version 4:
- If you are self-signing your requests, refer to our documentation for Authenticating requests to the Amazon SES API [1] and creating a canonical request for Signature Version 4 [2].
- If you are not self-signing your requests, simply update your SDK/CLI to the latest version.

The Amazon SES team will update the request information weekly and will stop notifications once we identify that Signature Version 3 is no longer being used from your account.

Closes #97 