### PR TITLE
SMTP_SSL requires host=None when connecting later.

### DIFF
--- a/marrow/mailer/transport/smtp.py
+++ b/marrow/mailer/transport/smtp.py
@@ -68,7 +68,7 @@ class SMTPTransport(object):
 
     def connect_to_server(self):
         if self.tls == 'ssl': # pragma: no cover
-            connection = SMTP_SSL(local_hostname=self.local_hostname, keyfile=self.keyfile,
+            connection = SMTP_SSL(host=None, local_hostname=self.local_hostname, keyfile=self.keyfile,
                                   certfile=self.certfile, timeout=self.timeout)
         else:
             connection = SMTP(local_hostname=self.local_hostname, timeout=self.timeout)


### PR DESCRIPTION
There is an apparent bug in SMTP_SSL that defaults host to empty string.

Setting host explicitly to None makes it very clear in the code that omitting the host is deliberate anyway.  But it also works around the bug in the Python upstream.


